### PR TITLE
support "input.env" as positional argument

### DIFF
--- a/clone-and-build.sh
+++ b/clone-and-build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-source input.env
+
+source ${1:-input.env}
 
 SCRIPT_DIR=$(pwd)
 TMP_DIR=$(mktemp -d "/tmp/cachi2.play.XXXXXXXXXX")


### PR DESCRIPTION
Original behavior is maintained when no argument is provided.